### PR TITLE
feat: infrastructure foundation — DB, Redis, shared types

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: "3.9"
+
+services:
+  db:
+    image: timescale/timescaledb:latest-pg16
+    container_name: polkadot-feed-db
+    restart: unless-stopped
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: polkadot
+      POSTGRES_PASSWORD: polkadot
+      POSTGRES_DB: polkadot_feed
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U polkadot -d polkadot_feed"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: polkadot-feed-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata:
+  redisdata:

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -3,8 +3,8 @@ PORT=3001
 HOST=0.0.0.0
 FRONTEND_URL=http://localhost:3000
 
-# Database
-DATABASE_URL=postgresql://localhost:5432/polkadot_feed
+# Database (matches docker-compose defaults)
+DATABASE_URL=postgresql://polkadot:polkadot@localhost:5432/polkadot_feed
 
 # Redis
 REDIS_URL=redis://localhost:6379

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -9,7 +9,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "lint": "eslint . --ext .ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "db:migrate": "tsx src/db/migrate.ts"
   },
   "dependencies": {
     "@polkadot-feed/shared": "*",

--- a/packages/backend/src/db/migrate.ts
+++ b/packages/backend/src/db/migrate.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { getPool, closePool } from "../services/database.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATIONS_DIR = path.join(__dirname, "migrations");
+
+async function migrate(): Promise<void> {
+  const pool = getPool();
+
+  const files = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+
+  for (const file of files) {
+    const filePath = path.join(MIGRATIONS_DIR, file);
+    const sql = fs.readFileSync(filePath, "utf-8");
+
+    console.log(`Running migration: ${file}`);
+    await pool.query(sql);
+    console.log(`Completed: ${file}`);
+  }
+
+  await closePool();
+  console.log("All migrations complete.");
+}
+
+migrate().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});

--- a/packages/backend/src/db/migrations/001_initial_schema.sql
+++ b/packages/backend/src/db/migrations/001_initial_schema.sql
@@ -1,0 +1,36 @@
+-- 001_initial_schema.sql
+-- Polkadot Activity Feed — Events table with TimescaleDB
+
+-- Enable TimescaleDB extension
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+-- Events table — unified schema for all chain events
+CREATE TABLE IF NOT EXISTS events (
+  id            BIGSERIAL       NOT NULL,
+  chain_id      TEXT            NOT NULL,
+  block_number  BIGINT          NOT NULL,
+  timestamp     TIMESTAMPTZ     NOT NULL,
+  event_type    TEXT            NOT NULL,
+  pallet        TEXT            NOT NULL,
+  method        TEXT            NOT NULL,
+  accounts      TEXT[]          NOT NULL DEFAULT '{}',
+  data          JSONB           NOT NULL DEFAULT '{}',
+  significance  SMALLINT        NOT NULL DEFAULT 0,
+  created_at    TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+
+  -- Composite primary key required by TimescaleDB hypertable
+  PRIMARY KEY (id, timestamp)
+);
+
+-- Convert to TimescaleDB hypertable partitioned by timestamp
+-- Chunk interval: 1 day (tunable based on ingestion volume)
+SELECT create_hypertable('events', 'timestamp', chunk_time_interval => INTERVAL '1 day');
+
+-- Indexes for common query patterns
+CREATE INDEX idx_events_type_time ON events (event_type, timestamp DESC);
+CREATE INDEX idx_events_chain_time ON events (chain_id, timestamp DESC);
+CREATE INDEX idx_events_accounts ON events USING GIN (accounts);
+CREATE INDEX idx_events_significance ON events (significance, timestamp DESC);
+
+-- Composite index for filtered feed queries (chain + type + time)
+CREATE INDEX idx_events_chain_type_time ON events (chain_id, event_type, timestamp DESC);

--- a/packages/backend/src/routes/health.ts
+++ b/packages/backend/src/routes/health.ts
@@ -1,7 +1,16 @@
 import type { FastifyInstance } from "fastify";
+import { healthCheck as dbHealthCheck } from "../services/database.js";
 
 export function registerHealthRoutes(app: FastifyInstance) {
   app.get("/health", async () => {
-    return { status: "ok", timestamp: new Date().toISOString() };
+    const dbHealthy = await dbHealthCheck();
+
+    return {
+      status: dbHealthy ? "ok" : "degraded",
+      timestamp: new Date().toISOString(),
+      services: {
+        database: dbHealthy ? "up" : "down",
+      },
+    };
   });
 }

--- a/packages/backend/src/routes/health.ts
+++ b/packages/backend/src/routes/health.ts
@@ -1,15 +1,22 @@
 import type { FastifyInstance } from "fastify";
 import { healthCheck as dbHealthCheck } from "../services/database.js";
+import { healthCheck as redisHealthCheck } from "../services/redis.js";
 
 export function registerHealthRoutes(app: FastifyInstance) {
   app.get("/health", async () => {
-    const dbHealthy = await dbHealthCheck();
+    const [dbHealthy, redisHealthy] = await Promise.all([
+      dbHealthCheck(),
+      redisHealthCheck(),
+    ]);
+
+    const allHealthy = dbHealthy && redisHealthy;
 
     return {
-      status: dbHealthy ? "ok" : "degraded",
+      status: allHealthy ? "ok" : "degraded",
       timestamp: new Date().toISOString(),
       services: {
         database: dbHealthy ? "up" : "down",
+        redis: redisHealthy ? "up" : "down",
       },
     };
   });

--- a/packages/backend/src/services/database.ts
+++ b/packages/backend/src/services/database.ts
@@ -2,17 +2,38 @@ import pg from "pg";
 
 const { Pool } = pg;
 
+const DATABASE_URL =
+  process.env.DATABASE_URL ||
+  "postgresql://polkadot:polkadot@localhost:5432/polkadot_feed";
+
 let pool: pg.Pool | null = null;
 
 export function getPool(): pg.Pool {
   if (!pool) {
     pool = new Pool({
-      connectionString:
-        process.env.DATABASE_URL ||
-        "postgresql://localhost:5432/polkadot_feed",
+      connectionString: DATABASE_URL,
+      max: 20,
+      idleTimeoutMillis: 30_000,
+      connectionTimeoutMillis: 5_000,
     });
   }
   return pool;
+}
+
+export async function query(
+  text: string,
+  params?: unknown[],
+): Promise<pg.QueryResult> {
+  return getPool().query(text, params);
+}
+
+export async function healthCheck(): Promise<boolean> {
+  try {
+    await query("SELECT 1");
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export async function closePool(): Promise<void> {

--- a/packages/backend/src/services/redis.ts
+++ b/packages/backend/src/services/redis.ts
@@ -1,22 +1,71 @@
 import Redis from "ioredis";
 
+const REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
+
+/** Channel naming convention for event pub/sub */
+export const CHANNELS = {
+  /** All events across all chains */
+  all: "events:all",
+  /** Events for a specific chain: events:<chain_id> */
+  chain: (chainId: string) => `events:${chainId}`,
+} as const;
+
 let publisher: Redis | null = null;
 let subscriber: Redis | null = null;
 
-const REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";
+function createClient(label: string): Redis {
+  const client = new Redis(REDIS_URL, {
+    maxRetriesPerRequest: 3,
+    retryStrategy(times) {
+      const delay = Math.min(times * 200, 5_000);
+      return delay;
+    },
+    lazyConnect: false,
+  });
+
+  client.on("connect", () => {
+    console.log(`Redis ${label}: connected`);
+  });
+
+  client.on("error", (err) => {
+    console.error(`Redis ${label} error:`, err.message);
+  });
+
+  return client;
+}
 
 export function getPublisher(): Redis {
   if (!publisher) {
-    publisher = new Redis(REDIS_URL);
+    publisher = createClient("publisher");
   }
   return publisher;
 }
 
 export function getSubscriber(): Redis {
   if (!subscriber) {
-    subscriber = new Redis(REDIS_URL);
+    subscriber = createClient("subscriber");
   }
   return subscriber;
+}
+
+export async function publishEvent(
+  chainId: string,
+  payload: string,
+): Promise<void> {
+  const pub = getPublisher();
+  await Promise.all([
+    pub.publish(CHANNELS.all, payload),
+    pub.publish(CHANNELS.chain(chainId), payload),
+  ]);
+}
+
+export async function healthCheck(): Promise<boolean> {
+  try {
+    const result = await getPublisher().ping();
+    return result === "PONG";
+  } catch {
+    return false;
+  }
 }
 
 export async function closeRedis(): Promise<void> {

--- a/packages/shared/src/chains.ts
+++ b/packages/shared/src/chains.ts
@@ -1,36 +1,62 @@
-import type { ChainConfig } from "./types.js";
+import type { ChainConfig, ChainId } from "./types.js";
 
 export const MVP_CHAINS: ChainConfig[] = [
   {
     id: "polkadot",
     name: "Polkadot",
+    displayName: "Polkadot Relay Chain",
     wsEndpoint: "wss://polkadot.api.onfinality.io/public-ws",
+    ss58Prefix: 0,
+    nativeToken: "DOT",
+    decimals: 10,
     color: "#E6007A",
   },
   {
     id: "asset-hub",
     name: "Asset Hub",
+    displayName: "Polkadot Asset Hub",
     wsEndpoint: "wss://statemint.api.onfinality.io/public-ws",
+    ss58Prefix: 0,
+    nativeToken: "DOT",
+    decimals: 10,
     color: "#00B2FF",
   },
   {
     id: "moonbeam",
     name: "Moonbeam",
+    displayName: "Moonbeam",
     wsEndpoint: "wss://moonbeam.api.onfinality.io/public-ws",
+    ss58Prefix: 1284,
+    nativeToken: "GLMR",
+    decimals: 18,
     color: "#53CBC9",
   },
   {
     id: "hydration",
     name: "Hydration",
+    displayName: "Hydration (HydraDX)",
     wsEndpoint: "wss://hydradx.api.onfinality.io/public-ws",
+    ss58Prefix: 63,
+    nativeToken: "HDX",
+    decimals: 12,
     color: "#4CFAC7",
   },
   {
     id: "acala",
     name: "Acala",
+    displayName: "Acala Network",
     wsEndpoint: "wss://acala-polkadot.api.onfinality.io/public-ws",
+    ss58Prefix: 10,
+    nativeToken: "ACA",
+    decimals: 12,
     color: "#E40C5B",
   },
 ];
 
-export const CHAIN_MAP = new Map(MVP_CHAINS.map((c) => [c.id, c]));
+/** Map of chain ID to config for quick lookups */
+export const CHAIN_MAP = new Map<ChainId, ChainConfig>(
+  MVP_CHAINS.map((c) => [c.id, c]),
+);
+
+/** All MVP chain IDs */
+export const MVP_CHAIN_IDS: ChainId[] = MVP_CHAINS.map((c) => c.id);

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,5 +1,7 @@
-/** Event category → event type mapping */
-export const CATEGORY_EVENT_TYPES: Record<string, string[]> = {
+import type { EventCategory, EventType } from "./types.js";
+
+/** Event category to event type mapping */
+export const CATEGORY_EVENT_TYPES: Record<EventCategory, EventType[]> = {
   transfers: ["transfer"],
   xcm: ["xcm_sent", "xcm_received", "xcm_failed"],
   governance: [
@@ -16,11 +18,40 @@ export const CATEGORY_EVENT_TYPES: Record<string, string[]> = {
   parachains: ["coretime_purchased"],
 };
 
+/** All event categories */
+export const EVENT_CATEGORIES: EventCategory[] = [
+  "transfers",
+  "xcm",
+  "governance",
+  "staking",
+  "runtime",
+  "identity",
+  "defi",
+  "parachains",
+];
+
 /** Significance labels */
 export const SIGNIFICANCE_LABELS = ["Normal", "Notable", "Major"] as const;
 
 /** Default pagination limit */
 export const DEFAULT_PAGE_SIZE = 50;
 
+/** Maximum pagination limit */
+export const MAX_PAGE_SIZE = 200;
+
 /** WebSocket heartbeat interval (ms) */
 export const WS_HEARTBEAT_INTERVAL = 30_000;
+
+/** WebSocket reconnect base delay (ms) */
+export const WS_RECONNECT_BASE_DELAY = 1_000;
+
+/** WebSocket reconnect max delay (ms) */
+export const WS_RECONNECT_MAX_DELAY = 30_000;
+
+/** Transfer significance thresholds (in native token base units) */
+export const SIGNIFICANCE_THRESHOLDS = {
+  /** Transfers above this are Notable (10K DOT = 10K * 10^10 planck) */
+  notable: 100_000_000_000_000n,
+  /** Transfers above this are Major (100K DOT) */
+  major: 1_000_000_000_000_000n,
+} as const;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,7 +1,15 @@
+/** MVP chain identifiers */
+export type ChainId =
+  | "polkadot"
+  | "asset-hub"
+  | "moonbeam"
+  | "hydration"
+  | "acala";
+
 /** Unified event schema matching the PostgreSQL events table */
 export interface ChainEvent {
   id: string;
-  chainId: string;
+  chainId: ChainId;
   blockNumber: number;
   timestamp: string;
   eventType: EventType;
@@ -13,6 +21,7 @@ export interface ChainEvent {
   createdAt: string;
 }
 
+/** All trackable event types across the ecosystem */
 export type EventType =
   | "transfer"
   | "xcm_sent"
@@ -32,8 +41,10 @@ export type EventType =
   | "swap_executed"
   | "coretime_purchased";
 
+/** Significance levels: 0=Normal, 1=Notable, 2=Major */
 export type Significance = 0 | 1 | 2;
 
+/** Event categories grouping related event types */
 export type EventCategory =
   | "transfers"
   | "xcm"
@@ -44,31 +55,65 @@ export type EventCategory =
   | "defi"
   | "parachains";
 
+/** Chain configuration for connecting to and displaying a parachain */
+export interface ChainConfig {
+  id: ChainId;
+  name: string;
+  displayName: string;
+  wsEndpoint: string;
+  ss58Prefix: number;
+  nativeToken: string;
+  decimals: number;
+  color: string;
+  logo?: string;
+}
+
+/** Filter criteria for querying events */
 export interface EventFilter {
-  chains?: string[];
+  chains?: ChainId[];
   eventTypes?: EventType[];
   categories?: EventCategory[];
   minSignificance?: Significance;
+  minAmount?: number;
   accounts?: string[];
   limit?: number;
   cursor?: string;
 }
 
-export interface PaginatedEvents {
-  events: ChainEvent[];
+/** Generic paginated response for cursor-based pagination */
+export interface PaginatedResponse<T> {
+  items: T[];
   nextCursor: string | null;
   hasMore: boolean;
 }
 
-export interface ChainConfig {
-  id: string;
-  name: string;
-  wsEndpoint: string;
-  logo?: string;
-  color: string;
-}
+/** Paginated events (convenience alias) */
+export type PaginatedEvents = PaginatedResponse<ChainEvent>;
 
+/** WebSocket message types for client-server communication */
 export interface WebSocketMessage {
   type: "new_event" | "subscribe" | "unsubscribe" | "ping" | "pong";
   payload: unknown;
+}
+
+/** WebSocket subscription request payload */
+export interface SubscribePayload {
+  chains?: ChainId[];
+  eventTypes?: EventType[];
+  minSignificance?: Significance;
+}
+
+/** Row shape from PostgreSQL events table (snake_case) */
+export interface EventRow {
+  id: string;
+  chain_id: string;
+  block_number: string;
+  timestamp: string;
+  event_type: string;
+  pallet: string;
+  method: string;
+  accounts: string[];
+  data: Record<string, unknown>;
+  significance: number;
+  created_at: string;
 }


### PR DESCRIPTION
## Summary
Sets up the foundational infrastructure layer that all M1 backend and frontend work depends on: database schema, Redis pub/sub, and expanded shared types.

## Changes
- PostgreSQL + TimescaleDB schema with events hypertable and indexes
- Migration runner script (`npm run db:migrate -w packages/backend`)
- docker-compose with TimescaleDB and Redis containers
- Redis Pub/Sub service with channel conventions (`events:all`, `events:<chain>`)
- Expanded shared types: ChainId, EventRow, PaginatedResponse<T>, SubscribePayload
- Expanded chain configs with ss58Prefix, nativeToken, decimals
- Significance thresholds and pagination constants
- Health check endpoint with DB + Redis status

## Testing
- [x] `npm run build -w packages/shared` — PASS
- [x] Shared types importable as `@polkadot-feed/shared`

## Acceptance Criteria
- [x] docker-compose starts TimescaleDB + Redis containers
- [x] Migration SQL creates events hypertable with all indexes
- [x] Database service exports query() and healthCheck()
- [x] Redis service exports publisher/subscriber with channel conventions
- [x] Shared types match PostgreSQL schema and PRD requirements
- [x] ChainConfig includes all 5 MVP chains with full metadata

Closes #1, Closes #2, Closes #3