### PR TITLE
feat: frontend core feed — UI components, feed page, filters, WebSocket

### DIFF
--- a/packages/frontend/.eslintrc.json
+++ b/packages/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/packages/frontend/src/app/page.tsx
+++ b/packages/frontend/src/app/page.tsx
@@ -1,15 +1,5 @@
+import { FeedPage } from "@/components/feed/FeedPage";
+
 export default function Home() {
-  return (
-    <main className="mx-auto max-w-5xl px-4 py-8">
-      <h1 className="mb-2 text-3xl font-bold tracking-tight">
-        Polkadot Activity Feed
-      </h1>
-      <p className="mb-8 text-gray-400">
-        Real-time events across Polkadot parachains
-      </p>
-      <div className="rounded-lg border border-gray-800 bg-gray-900 p-8 text-center text-gray-500">
-        Feed loading...
-      </div>
-    </main>
-  );
+  return <FeedPage />;
 }

--- a/packages/frontend/src/components/feed/EventCard.tsx
+++ b/packages/frontend/src/components/feed/EventCard.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import type { ChainEvent } from "@polkadot-feed/shared";
+import { CHAIN_MAP } from "@polkadot-feed/shared";
+import { Badge } from "@/components/ui/Badge";
+import { Card, CardHeader, CardContent } from "@/components/ui/Card";
+import {
+  formatTimestamp,
+  truncateAddress,
+  SIGNIFICANCE_LABEL,
+  SIGNIFICANCE_DOT,
+  cn,
+} from "@/lib/utils";
+
+interface EventCardProps {
+  event: ChainEvent;
+  isExpanded?: boolean;
+  onToggle: () => void;
+}
+
+/** Human-readable label for an event type */
+function formatEventType(eventType: string): string {
+  return eventType
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Render a small summary of the most important data fields */
+function EventSummary({ data }: { data: Record<string, unknown> }) {
+  const entries = Object.entries(data).slice(0, 3);
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500">
+      {entries.map(([key, val]) => (
+        <span key={key}>
+          <span className="text-gray-600">{key}:</span>{" "}
+          <span className="text-gray-400 font-mono">
+            {typeof val === "bigint"
+              ? val.toString()
+              : typeof val === "object"
+              ? JSON.stringify(val).slice(0, 40)
+              : String(val).slice(0, 40)}
+          </span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function EventCard({ event, onToggle }: EventCardProps) {
+  const chain = CHAIN_MAP.get(event.chainId);
+  const chainColor = chain?.color ?? "#888";
+  const chainName = chain?.name ?? event.chainId;
+
+  return (
+    <Card onClick={onToggle} className="group">
+      <CardHeader>
+        <div className="flex items-center gap-2 flex-wrap">
+          {/* Chain badge */}
+          <Badge
+            style={{ backgroundColor: chainColor + "26", color: chainColor }}
+            className="font-semibold"
+          >
+            {chainName}
+          </Badge>
+
+          {/* Event type badge */}
+          <Badge variant="outline">
+            {formatEventType(event.eventType)}
+          </Badge>
+
+          {/* Significance indicator */}
+          <span className="flex items-center gap-1">
+            <span
+              className={cn(
+                "inline-block h-2 w-2 rounded-full",
+                SIGNIFICANCE_DOT[event.significance],
+              )}
+            />
+            {event.significance > 0 && (
+              <span
+                className={cn(
+                  "text-xs font-medium",
+                  event.significance === 2 ? "text-red-400" : "text-yellow-400",
+                )}
+              >
+                {SIGNIFICANCE_LABEL[event.significance]}
+              </span>
+            )}
+          </span>
+        </div>
+
+        {/* Timestamp */}
+        <span
+          className="shrink-0 text-xs text-gray-500"
+          title={new Date(event.timestamp).toLocaleString()}
+        >
+          {formatTimestamp(event.timestamp)}
+        </span>
+      </CardHeader>
+
+      <CardContent>
+        {/* Accounts */}
+        {event.accounts.length > 0 && (
+          <div className="mb-1 flex flex-wrap gap-2">
+            {event.accounts.slice(0, 3).map((addr, i) => (
+              <span
+                key={i}
+                className="rounded bg-gray-800 px-1.5 py-0.5 font-mono text-xs text-gray-300"
+                title={addr}
+              >
+                {truncateAddress(addr)}
+              </span>
+            ))}
+            {event.accounts.length > 3 && (
+              <span className="text-xs text-gray-600">
+                +{event.accounts.length - 3} more
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Key data summary */}
+        <EventSummary data={event.data} />
+
+        {/* Block number */}
+        <div className="mt-2 text-xs text-gray-600">
+          Block #{event.blockNumber.toLocaleString()}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/frontend/src/components/feed/EventDetail.tsx
+++ b/packages/frontend/src/components/feed/EventDetail.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState } from "react";
+import type { ChainEvent } from "@polkadot-feed/shared";
+import { CHAIN_MAP } from "@polkadot-feed/shared";
+import { Button } from "@/components/ui/Button";
+import { truncateAddress, SIGNIFICANCE_LABEL } from "@/lib/utils";
+
+interface EventDetailProps {
+  event: ChainEvent;
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="ml-1 rounded px-1.5 py-0.5 text-xs text-gray-500 transition-colors hover:bg-gray-700 hover:text-gray-300"
+      title="Copy to clipboard"
+    >
+      {copied ? "Copied" : "Copy"}
+    </button>
+  );
+}
+
+function DataRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-start gap-2 py-1.5 text-sm">
+      <span className="w-36 shrink-0 text-gray-500">{label}</span>
+      <span className="break-all font-mono text-gray-300">{value}</span>
+    </div>
+  );
+}
+
+export function EventDetail({ event }: EventDetailProps) {
+  const [showRaw, setShowRaw] = useState(false);
+  const chain = CHAIN_MAP.get(event.chainId);
+  const subscanBase = getSubscanBase(event.chainId);
+
+  return (
+    <div
+      onClick={(e) => e.stopPropagation()}
+      className="mx-1 mb-2 rounded-b-lg border border-t-0 border-gray-800 bg-gray-900/60 px-4 py-3"
+    >
+      {/* Core event metadata */}
+      <div className="mb-3 divide-y divide-gray-800/60">
+        <DataRow label="Event ID" value={event.id} />
+        <DataRow label="Chain" value={chain?.displayName ?? event.chainId} />
+        <DataRow label="Pallet" value={event.pallet} />
+        <DataRow label="Method" value={event.method} />
+        <DataRow label="Block" value={`#${event.blockNumber.toLocaleString()}`} />
+        <DataRow label="Timestamp" value={new Date(event.timestamp).toLocaleString()} />
+        <DataRow label="Significance" value={SIGNIFICANCE_LABEL[event.significance]} />
+      </div>
+
+      {/* Accounts */}
+      {event.accounts.length > 0 && (
+        <div className="mb-3">
+          <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-gray-500">
+            Accounts
+          </p>
+          <div className="space-y-1">
+            {event.accounts.map((addr, i) => (
+              <div key={i} className="flex items-center gap-1">
+                <span
+                  className="rounded bg-gray-800 px-2 py-0.5 font-mono text-xs text-gray-300"
+                  title={addr}
+                >
+                  {truncateAddress(addr)}
+                </span>
+                <CopyButton text={addr} />
+                {subscanBase && (
+                  <a
+                    href={`${subscanBase}/account/${addr}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="ml-1 text-xs text-pink-500 hover:text-pink-400"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    Subscan
+                  </a>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Event data key-value pairs */}
+      {Object.keys(event.data).length > 0 && (
+        <div className="mb-3">
+          <p className="mb-1 text-xs font-semibold uppercase tracking-wider text-gray-500">
+            Event Data
+          </p>
+          <div className="divide-y divide-gray-800/60 rounded border border-gray-800 bg-gray-950/50">
+            {Object.entries(event.data).map(([key, val]) => (
+              <div key={key} className="flex items-start gap-2 px-3 py-1.5 text-xs">
+                <span className="w-32 shrink-0 text-gray-500">{key}</span>
+                <span className="break-all font-mono text-gray-300">
+                  {typeof val === "bigint"
+                    ? val.toString()
+                    : typeof val === "object"
+                    ? JSON.stringify(val)
+                    : String(val)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Links + Raw JSON toggle */}
+      <div className="flex items-center gap-3 pt-1">
+        {subscanBase && (
+          <a
+            href={`${subscanBase}/block/${event.blockNumber}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-pink-500 hover:text-pink-400"
+            onClick={(e) => e.stopPropagation()}
+          >
+            View block on Subscan
+          </a>
+        )}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={(e) => {
+            e.stopPropagation();
+            setShowRaw((v) => !v);
+          }}
+        >
+          {showRaw ? "Hide raw JSON" : "Show raw JSON"}
+        </Button>
+      </div>
+
+      {showRaw && (
+        <pre className="mt-3 max-h-64 overflow-auto rounded border border-gray-800 bg-gray-950 p-3 text-xs text-gray-400">
+          {JSON.stringify(event, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+function getSubscanBase(chainId: string): string | null {
+  const subscanMap: Record<string, string> = {
+    polkadot: "https://polkadot.subscan.io",
+    "asset-hub": "https://assethub-polkadot.subscan.io",
+    moonbeam: "https://moonbeam.subscan.io",
+    hydration: "https://hydradx.subscan.io",
+    acala: "https://acala.subscan.io",
+  };
+  return subscanMap[chainId] ?? null;
+}

--- a/packages/frontend/src/components/feed/EventFeed.tsx
+++ b/packages/frontend/src/components/feed/EventFeed.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import type { ChainEvent } from "@polkadot-feed/shared";
+import { EventCard } from "./EventCard";
+import { EventDetail } from "./EventDetail";
+import { Button } from "@/components/ui/Button";
+
+interface EventFeedProps {
+  initialEvents: ChainEvent[];
+  hasMore: boolean;
+  onLoadMore: () => Promise<void>;
+  isLoading?: boolean;
+}
+
+export function EventFeed({
+  initialEvents,
+  hasMore,
+  onLoadMore,
+  isLoading = false,
+}: EventFeedProps) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const handleLoadMore = async () => {
+    setLoadingMore(true);
+    try {
+      await onLoadMore();
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  const handleToggle = (id: string) => {
+    setExpandedId((prev) => (prev === id ? null : id));
+  };
+
+  if (isLoading && initialEvents.length === 0) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div
+            key={i}
+            className="h-24 animate-pulse rounded-lg border border-gray-800 bg-gray-900"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (!isLoading && initialEvents.length === 0) {
+    return (
+      <div className="rounded-lg border border-gray-800 bg-gray-900 p-12 text-center text-gray-500">
+        No events found. Try adjusting your filters.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {initialEvents.map((event) => (
+        <div key={event.id}>
+          <EventCard
+            event={event}
+            isExpanded={expandedId === event.id}
+            onToggle={() => handleToggle(event.id)}
+          />
+          {expandedId === event.id && (
+            <EventDetail event={event} />
+          )}
+        </div>
+      ))}
+
+      {hasMore && (
+        <div className="flex justify-center pt-4">
+          <Button
+            onClick={handleLoadMore}
+            disabled={loadingMore}
+            variant="outline"
+            size="md"
+          >
+            {loadingMore ? "Loading..." : "Load more"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/feed/FeedFilters.tsx
+++ b/packages/frontend/src/components/feed/FeedFilters.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import type { ChainId, EventType, Significance } from "@polkadot-feed/shared";
+import { MVP_CHAINS, EVENT_CATEGORIES, CATEGORY_EVENT_TYPES } from "@polkadot-feed/shared";
+import type { FeedFilterState } from "./FeedPage";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/Button";
+
+interface FeedFiltersProps {
+  filters: FeedFilterState;
+  onChange: (filters: FeedFilterState) => void;
+}
+
+const SIGNIFICANCE_OPTIONS: { value: Significance; label: string }[] = [
+  { value: 0, label: "All" },
+  { value: 1, label: "Notable+" },
+  { value: 2, label: "Major only" },
+];
+
+export function FeedFilters({ filters, onChange }: FeedFiltersProps) {
+  const toggleChain = (chainId: ChainId) => {
+    const next = filters.chains.includes(chainId)
+      ? filters.chains.filter((c) => c !== chainId)
+      : [...filters.chains, chainId];
+    onChange({ ...filters, chains: next });
+  };
+
+  const toggleCategory = (eventTypes: EventType[]) => {
+    const allSelected = eventTypes.every((et) => filters.eventTypes.includes(et));
+    if (allSelected) {
+      onChange({
+        ...filters,
+        eventTypes: filters.eventTypes.filter((et) => !eventTypes.includes(et)),
+      });
+    } else {
+      const merged = Array.from(new Set([...filters.eventTypes, ...eventTypes]));
+      onChange({ ...filters, eventTypes: merged });
+    }
+  };
+
+  const isCategoryActive = (eventTypes: EventType[]) =>
+    eventTypes.every((et) => filters.eventTypes.includes(et));
+
+  const hasActiveFilters =
+    filters.chains.length > 0 ||
+    filters.eventTypes.length > 0 ||
+    filters.minSignificance > 0;
+
+  const clearFilters = () =>
+    onChange({ chains: [], eventTypes: [], minSignificance: 0 });
+
+  return (
+    <div className="rounded-lg border border-gray-800 bg-gray-900/50 p-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:flex-wrap sm:items-start">
+        {/* Chain filter */}
+        <div className="min-w-0 flex-1">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
+            Chains
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {MVP_CHAINS.map((chain) => {
+              const active = filters.chains.includes(chain.id);
+              return (
+                <button
+                  key={chain.id}
+                  onClick={() => toggleChain(chain.id)}
+                  style={{
+                    borderColor: active ? chain.color : undefined,
+                    color: active ? chain.color : undefined,
+                    backgroundColor: active ? chain.color + "1A" : undefined,
+                  }}
+                  className={cn(
+                    "rounded-full border px-3 py-1 text-xs font-medium transition-all",
+                    active
+                      ? "shadow-sm"
+                      : "border-gray-700 text-gray-400 hover:border-gray-500 hover:text-gray-300",
+                  )}
+                >
+                  {chain.name}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Category filter */}
+        <div className="min-w-0 flex-1">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
+            Categories
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {EVENT_CATEGORIES.map((category) => {
+              const categoryTypes = CATEGORY_EVENT_TYPES[category];
+              const active = isCategoryActive(categoryTypes);
+              return (
+                <button
+                  key={category}
+                  onClick={() => toggleCategory(categoryTypes)}
+                  className={cn(
+                    "rounded-full border px-3 py-1 text-xs font-medium capitalize transition-all",
+                    active
+                      ? "border-pink-600 bg-pink-600/10 text-pink-400"
+                      : "border-gray-700 text-gray-400 hover:border-gray-500 hover:text-gray-300",
+                  )}
+                >
+                  {category}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Significance filter */}
+        <div className="shrink-0">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-gray-500">
+            Significance
+          </p>
+          <div className="flex gap-2">
+            {SIGNIFICANCE_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => onChange({ ...filters, minSignificance: opt.value })}
+                className={cn(
+                  "rounded-full border px-3 py-1 text-xs font-medium transition-all",
+                  filters.minSignificance === opt.value
+                    ? "border-gray-400 bg-gray-700 text-gray-100"
+                    : "border-gray-700 text-gray-400 hover:border-gray-500 hover:text-gray-300",
+                )}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Clear filters */}
+      {hasActiveFilters && (
+        <div className="mt-3 flex justify-end">
+          <Button variant="ghost" size="sm" onClick={clearFilters}>
+            Clear filters
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/feed/FeedPage.tsx
+++ b/packages/frontend/src/components/feed/FeedPage.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import { useEvents } from "@/hooks/useEvents";
+import { EventFeed } from "./EventFeed";
+import { FeedFilters } from "./FeedFilters";
+import type { ChainId, EventType, Significance } from "@polkadot-feed/shared";
+
+export interface FeedFilterState {
+  chains: ChainId[];
+  eventTypes: EventType[];
+  minSignificance: Significance;
+}
+
+const DEFAULT_FILTERS: FeedFilterState = {
+  chains: [],
+  eventTypes: [],
+  minSignificance: 0,
+};
+
+export function FeedPage() {
+  const [filters, setFilters] = useState<FeedFilterState>(DEFAULT_FILTERS);
+  const { events, hasMore, isLoading, loadMore } = useEvents(filters);
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8">
+      <div className="mb-6">
+        <h1 className="mb-1 text-3xl font-bold tracking-tight">
+          Polkadot Activity Feed
+        </h1>
+        <p className="text-gray-400">
+          Real-time events across Polkadot parachains
+        </p>
+      </div>
+
+      <FeedFilters filters={filters} onChange={setFilters} />
+
+      <div className="mt-4">
+        <EventFeed
+          initialEvents={events}
+          hasMore={hasMore}
+          onLoadMore={loadMore}
+          isLoading={isLoading}
+        />
+      </div>
+    </main>
+  );
+}

--- a/packages/frontend/src/components/ui/Badge.tsx
+++ b/packages/frontend/src/components/ui/Badge.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils";
+
+interface BadgeProps {
+  children: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+  variant?: "default" | "outline";
+}
+
+export function Badge({ children, className, style, variant = "default" }: BadgeProps) {
+  return (
+    <span
+      style={style}
+      className={cn(
+        "inline-flex items-center rounded px-2 py-0.5 text-xs font-medium",
+        variant === "default" && "bg-gray-700 text-gray-200",
+        variant === "outline" && "border border-gray-600 text-gray-300",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/frontend/src/components/ui/Button.tsx
+++ b/packages/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,35 @@
+import { cn } from "@/lib/utils";
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: "primary" | "secondary" | "ghost" | "outline";
+  size?: "sm" | "md" | "lg";
+}
+
+export function Button({
+  children,
+  className,
+  variant = "secondary",
+  size = "md",
+  disabled,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      {...props}
+      disabled={disabled}
+      className={cn(
+        "inline-flex items-center justify-center rounded font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-500 disabled:cursor-not-allowed disabled:opacity-50",
+        size === "sm" && "px-3 py-1 text-xs",
+        size === "md" && "px-4 py-2 text-sm",
+        size === "lg" && "px-6 py-3 text-base",
+        variant === "primary" && "bg-pink-600 text-white hover:bg-pink-700",
+        variant === "secondary" && "bg-gray-700 text-gray-200 hover:bg-gray-600",
+        variant === "ghost" && "text-gray-400 hover:bg-gray-800 hover:text-gray-100",
+        variant === "outline" && "border border-gray-600 text-gray-300 hover:border-gray-500 hover:bg-gray-800",
+        className,
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/frontend/src/components/ui/Card.tsx
+++ b/packages/frontend/src/components/ui/Card.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils";
+
+interface CardProps {
+  children: React.ReactNode;
+  className?: string;
+  onClick?: () => void;
+}
+
+export function Card({ children, className, onClick }: CardProps) {
+  return (
+    <div
+      onClick={onClick}
+      className={cn(
+        "rounded-lg border border-gray-800 bg-gray-900 p-4",
+        onClick && "cursor-pointer transition-colors hover:border-gray-700 hover:bg-gray-800/80",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface CardHeaderProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function CardHeader({ children, className }: CardHeaderProps) {
+  return (
+    <div className={cn("mb-3 flex items-center justify-between gap-2", className)}>
+      {children}
+    </div>
+  );
+}
+
+interface CardContentProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function CardContent({ children, className }: CardContentProps) {
+  return <div className={cn("text-sm text-gray-400", className)}>{children}</div>;
+}

--- a/packages/frontend/src/components/ui/Select.tsx
+++ b/packages/frontend/src/components/ui/Select.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils";
+
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface SelectProps {
+  options: SelectOption[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+}
+
+export function Select({
+  options,
+  value,
+  onChange,
+  placeholder,
+  className,
+}: SelectProps) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className={cn(
+        "rounded border border-gray-700 bg-gray-800 px-3 py-1.5 text-sm text-gray-200 focus:border-gray-500 focus:outline-none",
+        className,
+      )}
+    >
+      {placeholder && (
+        <option value="" disabled>
+          {placeholder}
+        </option>
+      )}
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/packages/frontend/src/hooks/useEventStream.ts
+++ b/packages/frontend/src/hooks/useEventStream.ts
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import type { ChainEvent, SubscribePayload } from "@polkadot-feed/shared";
+
+const WS_URL = process.env.NEXT_PUBLIC_WS_URL ?? "ws://localhost:3001/ws";
+const BASE_DELAY = 1_000;
+const MAX_DELAY = 30_000;
+
+interface UseEventStreamOptions {
+  subscribePayload: SubscribePayload;
+  onEvent: (event: ChainEvent) => void;
+  enabled?: boolean;
+}
+
+/** Custom hook that connects to the WebSocket and emits new events */
+export function useEventStream({
+  subscribePayload,
+  onEvent,
+  enabled = true,
+}: UseEventStreamOptions): void {
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectDelayRef = useRef<number>(BASE_DELAY);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef<boolean>(true);
+  const onEventRef = useRef<(event: ChainEvent) => void>(onEvent);
+  const payloadRef = useRef<SubscribePayload>(subscribePayload);
+
+  // Keep refs current without triggering reconnects
+  useEffect(() => {
+    onEventRef.current = onEvent;
+  });
+  useEffect(() => {
+    payloadRef.current = subscribePayload;
+    // Re-subscribe if already connected
+    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+      wsRef.current.send(
+        JSON.stringify({ type: "subscribe", payload: subscribePayload }),
+      );
+    }
+  }, [subscribePayload]);
+
+  const connect = useCallback(() => {
+    if (!mountedRef.current || !enabled) return;
+
+    const ws = new WebSocket(WS_URL);
+    wsRef.current = ws;
+
+    ws.addEventListener("open", () => {
+      if (!mountedRef.current) return;
+      reconnectDelayRef.current = BASE_DELAY;
+      ws.send(
+        JSON.stringify({ type: "subscribe", payload: payloadRef.current }),
+      );
+    });
+
+    ws.addEventListener("message", (ev: MessageEvent<string>) => {
+      if (!mountedRef.current) return;
+      let msg: { type: string; payload: unknown };
+      try {
+        msg = JSON.parse(ev.data) as { type: string; payload: unknown };
+      } catch {
+        return;
+      }
+
+      if (msg.type === "ping") {
+        ws.send(JSON.stringify({ type: "pong", payload: null }));
+        return;
+      }
+
+      if (msg.type === "new_event") {
+        onEventRef.current(msg.payload as ChainEvent);
+      }
+    });
+
+    ws.addEventListener("close", () => {
+      if (!mountedRef.current) return;
+      scheduleReconnect();
+    });
+
+    ws.addEventListener("error", () => {
+      ws.close();
+    });
+  }, [enabled]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const scheduleReconnect = useCallback(() => {
+    if (!mountedRef.current) return;
+    const delay = reconnectDelayRef.current;
+    reconnectDelayRef.current = Math.min(delay * 2, MAX_DELAY);
+    reconnectTimerRef.current = setTimeout(() => {
+      connect();
+    }, delay);
+  }, [connect]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    if (enabled) {
+      connect();
+    }
+
+    return () => {
+      mountedRef.current = false;
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current);
+      }
+      if (wsRef.current) {
+        wsRef.current.close();
+        wsRef.current = null;
+      }
+    };
+  }, [enabled, connect]);
+}

--- a/packages/frontend/src/hooks/useEvents.ts
+++ b/packages/frontend/src/hooks/useEvents.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { ChainEvent } from "@polkadot-feed/shared";
+import { fetchEvents } from "@/lib/api";
+import { useEventStream } from "./useEventStream";
+import type { FeedFilterState } from "@/components/feed/FeedPage";
+
+const PAGE_SIZE = 50;
+
+interface UseEventsResult {
+  events: ChainEvent[];
+  hasMore: boolean;
+  isLoading: boolean;
+  loadMore: () => Promise<void>;
+}
+
+/** Combines REST pagination with WebSocket live updates */
+export function useEvents(filters: FeedFilterState): UseEventsResult {
+  const [events, setEvents] = useState<ChainEvent[]>([]);
+  const [hasMore, setHasMore] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [cursor, setCursor] = useState<string | null>(null);
+
+  // Deduplicate by id using a set
+  const seenIds = useRef<Set<string>>(new Set());
+
+  const addEvents = useCallback(
+    (incoming: ChainEvent[], prepend = false) => {
+      const fresh = incoming.filter((e) => !seenIds.current.has(e.id));
+      fresh.forEach((e) => seenIds.current.add(e.id));
+      if (fresh.length === 0) return;
+      setEvents((prev) =>
+        prepend ? [...fresh, ...prev] : [...prev, ...fresh],
+      );
+    },
+    [],
+  );
+
+  const filtersKey = JSON.stringify(filters);
+
+  // Initial load and filter change reload
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    let cancelled = false;
+    seenIds.current = new Set();
+
+    setIsLoading(true);
+    setEvents([]);
+    setCursor(null);
+
+    void (async () => {
+      try {
+        const result = await fetchEvents({
+          chains: filters.chains.length > 0 ? filters.chains : undefined,
+          eventTypes: filters.eventTypes.length > 0 ? filters.eventTypes : undefined,
+          minSignificance: filters.minSignificance > 0 ? filters.minSignificance : undefined,
+          limit: PAGE_SIZE,
+        });
+
+        if (cancelled) return;
+
+        result.items.forEach((e) => seenIds.current.add(e.id));
+        setEvents(result.items);
+        setHasMore(result.hasMore);
+        setCursor(result.nextCursor);
+      } catch {
+        // Silently handle fetch error — feed shows empty state
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [filtersKey]); // filtersKey is a stable serialization of the filters object
+
+  const loadMore = useCallback(async () => {
+    if (!hasMore || !cursor) return;
+    try {
+      const result = await fetchEvents({
+        chains: filters.chains.length > 0 ? filters.chains : undefined,
+        eventTypes: filters.eventTypes.length > 0 ? filters.eventTypes : undefined,
+        minSignificance: filters.minSignificance > 0 ? filters.minSignificance : undefined,
+        limit: PAGE_SIZE,
+        cursor,
+      });
+      addEvents(result.items);
+      setHasMore(result.hasMore);
+      setCursor(result.nextCursor);
+    } catch {
+      // Error handled silently; user can retry via the button
+    }
+  }, [hasMore, cursor, filters, addEvents]);
+
+  // WebSocket live updates
+  const subscribePayload = {
+    chains: filters.chains.length > 0 ? filters.chains : undefined,
+    eventTypes: filters.eventTypes.length > 0 ? filters.eventTypes : undefined,
+    minSignificance: filters.minSignificance > 0 ? filters.minSignificance : undefined,
+  };
+
+  useEventStream({
+    subscribePayload,
+    onEvent: (event) => addEvents([event], true),
+  });
+
+  return { events, hasMore, isLoading, loadMore };
+}

--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -1,0 +1,63 @@
+import type {
+  ChainEvent,
+  ChainId,
+  EventType,
+  PaginatedEvents,
+  Significance,
+} from "@polkadot-feed/shared";
+
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL ?? "http://localhost:3001";
+
+export interface FetchEventsParams {
+  chains?: ChainId[];
+  eventTypes?: EventType[];
+  minSignificance?: Significance;
+  limit?: number;
+  cursor?: string;
+}
+
+/** Fetch paginated events from the backend REST API */
+export async function fetchEvents(
+  params: FetchEventsParams = {},
+): Promise<PaginatedEvents> {
+  const url = new URL("/api/events", BACKEND_URL);
+
+  if (params.chains && params.chains.length > 0) {
+    url.searchParams.set("chains", params.chains.join(","));
+  }
+  if (params.eventTypes && params.eventTypes.length > 0) {
+    url.searchParams.set("eventTypes", params.eventTypes.join(","));
+  }
+  if (params.minSignificance !== undefined) {
+    url.searchParams.set("minSignificance", String(params.minSignificance));
+  }
+  if (params.limit !== undefined) {
+    url.searchParams.set("limit", String(params.limit));
+  }
+  if (params.cursor) {
+    url.searchParams.set("cursor", params.cursor);
+  }
+
+  const res = await fetch(url.toString(), {
+    next: { revalidate: 0 },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch events: ${res.status} ${res.statusText}`);
+  }
+
+  return res.json() as Promise<PaginatedEvents>;
+}
+
+/** Fetch a single event by ID */
+export async function fetchEvent(id: string): Promise<ChainEvent> {
+  const res = await fetch(`${BACKEND_URL}/api/events/${id}`, {
+    next: { revalidate: 0 },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch event ${id}: ${res.status} ${res.statusText}`);
+  }
+
+  return res.json() as Promise<ChainEvent>;
+}

--- a/packages/frontend/src/lib/utils.ts
+++ b/packages/frontend/src/lib/utils.ts
@@ -1,0 +1,64 @@
+import type { Significance } from "@polkadot-feed/shared";
+
+/** Merge Tailwind class strings, filtering out falsy values */
+export function cn(...classes: (string | undefined | null | false)[]): string {
+  return classes.filter(Boolean).join(" ");
+}
+
+/** Format an ISO timestamp to a human-readable relative or absolute string */
+export function formatTimestamp(iso: string): string {
+  const date = new Date(iso);
+  const now = Date.now();
+  const diffMs = now - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+
+  if (diffSec < 60) return `${diffSec}s ago`;
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`;
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+/** Format an ISO timestamp to a full readable string for tooltips */
+export function formatTimestampFull(iso: string): string {
+  const date = new Date(iso);
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    timeZoneName: "short",
+  });
+}
+
+/** Truncate a substrate/EVM address to show first 6 and last 4 chars */
+export function truncateAddress(address: string): string {
+  if (address.length <= 12) return address;
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+/** Map significance level to a label */
+export const SIGNIFICANCE_LABEL: Record<Significance, string> = {
+  0: "Normal",
+  1: "Notable",
+  2: "Major",
+};
+
+/** Map significance level to Tailwind color classes */
+export const SIGNIFICANCE_COLOR: Record<Significance, string> = {
+  0: "text-gray-400",
+  1: "text-yellow-400",
+  2: "text-red-400",
+};
+
+/** Map significance level to dot/ring classes for the indicator */
+export const SIGNIFICANCE_DOT: Record<Significance, string> = {
+  0: "bg-gray-500",
+  1: "bg-yellow-400",
+  2: "bg-red-500",
+};


### PR DESCRIPTION
## Summary
Implements the complete frontend for M1 Core Feed: UI component library, main feed page with event cards, chain/category/significance filters, event detail expanded view, and real-time WebSocket connection.

## Changes
- UI components: Badge, Button, Card, Select (Tailwind-only, dark theme)
- API client (`lib/api.ts`) for backend REST endpoint
- Utility helpers: cn(), formatTimestamp, truncateAddress
- EventCard with chain color badge, event type, significance dot, accounts
- EventFeed with loading skeletons, empty state, load-more pagination
- FeedFilters with chain pills, category pills, significance toggle
- EventDetail expanded view with full data, copy-to-clipboard, Subscan links, raw JSON
- useEventStream hook: WebSocket with exponential backoff reconnection
- useEvents hook: combines REST initial load with WebSocket live prepend, dedup by event ID
- FeedPage client component wiring filters → API → feed → WebSocket

## Testing
- [x] `next build` passes
- [x] `next lint` passes (1 non-fatal warning on exhaustive-deps)

## Acceptance Criteria
- [x] Feed page shows chronological event cards
- [x] Chain filter with colored pills for 5 MVP chains
- [x] Event category filter for 8 categories
- [x] Significance filter (All / Notable+ / Major)
- [x] Click event card to expand inline detail view
- [x] Accounts have copy button and Subscan links
- [x] Raw JSON toggle in detail view
- [x] WebSocket connects, subscribes with filter state, prepends live events
- [x] Reconnection with exponential backoff on disconnect
- [x] Dark theme throughout

Closes #8, Closes #9, Closes #10, Closes #11, Closes #12